### PR TITLE
Add stratum 1.1 scripthash methods

### DIFF
--- a/example/scripthash.js
+++ b/example/scripthash.js
@@ -1,0 +1,18 @@
+const ElectrumClient = require('..')
+
+const main = async () => {
+    const ecl = new ElectrumClient(50002, 'bitcoins.sk', 'tls')
+    await ecl.connect()
+    try{
+        const ver = await ecl.server_version("3.0.5", "1.1")
+        console.log(ver)
+        const balance = await ecl.blockchainScripthash_getBalance("676ca8550e249787290b987e12cebdb2e9b26d88c003d836ffb1cb03ffcbea7c")
+        console.log(balance)
+        const unspent = await ecl.blockchainScripthash_listunspent("676ca8550e249787290b987e12cebdb2e9b26d88c003d836ffb1cb03ffcbea7c")
+        console.log(unspent)
+    }catch(e){
+        console.log(e)
+    }
+    await ecl.close()
+}
+main().catch(console.log)

--- a/example/scripthash.js
+++ b/example/scripthash.js
@@ -10,6 +10,10 @@ const main = async () => {
         console.log(balance)
         const unspent = await ecl.blockchainScripthash_listunspent("676ca8550e249787290b987e12cebdb2e9b26d88c003d836ffb1cb03ffcbea7c")
         console.log(unspent)
+        const history = await ecl.blockchainScripthash_getHistory("676ca8550e249787290b987e12cebdb2e9b26d88c003d836ffb1cb03ffcbea7c")
+        console.log(history)
+        const mempool = await ecl.blockchainScripthash_getMempool("676ca8550e249787290b987e12cebdb2e9b26d88c003d836ffb1cb03ffcbea7c")
+        console.log(mempool)
     }catch(e){
         console.log(e)
     }

--- a/example/subscribe.js
+++ b/example/subscribe.js
@@ -3,17 +3,23 @@ const sleep = (ms) => new Promise((resolve,_) => setTimeout(() => resolve(), ms)
 
 const main = async () => {
     try{
-        const ecl = new ElectrumClient(995, 'btc.smsys.me', 'tls')
+        const ecl = new ElectrumClient(50002, 'bitcoins.sk', 'tls')
         ecl.subscribe.on('server.peers.subscribe', console.log)
         ecl.subscribe.on('blockchain.numblocks.subscribe', console.log)
         ecl.subscribe.on('blockchain.headers.subscribe', console.log)
+        ecl.subscribe.on('blockchain.address.subscribe', console.log)
+        ecl.subscribe.on('blockchain.scripthash.subscribe', console.log)
         await ecl.connect()
+        await ecl.server_version("3.0.5", "1.1")
         const p1 = await ecl.serverPeers_subscribe()
         const p2 = await ecl.blockchainHeaders_subscribe()
-        const p3 = await ecl.blockchainNumblocks_subscribe()
+        // Note: blockchain.numblocks.subscribe is deprecated in protocol version 1.1
+        const p3 = await ecl.blockchainAddress_subscribe('1BK45iaPrrd26gKagrXytvz6anrj3hQ2pQ')
+        // Subscribe to corresponding scripthash for the above address
+        const p4 = await ecl.blockchainScripthash_subscribe('f3aa57a41424146327e5c88c25db8953dd16c6ab6273cdb74a4404ed4d0f5714')
         while(true){
             await sleep(1000)
-            let version = await ecl.server_version("2.7.11", "1.0")
+            const ver = await ecl.server_version("3.0.5", "1.1")
         }
         await ecl.close()
     }catch(e){

--- a/lib/electrum_client.js
+++ b/lib/electrum_client.js
@@ -40,14 +40,20 @@ class ElectrumClient extends Client{
     blockchainAddress_listunspent(address){
         return this.request('blockchain.address.listunspent', [address])
     }
-    blockchainScripthash_getBalance(scripthash) {
-        return this.request('blockchain.scripthash.get_balance', [scripthash]);
+    blockchainScripthash_getBalance(scripthash){
+        return this.request('blockchain.scripthash.get_balance', [scripthash])
     }
-    blockchainScripthash_listunspent(scripthash) {
-        return this.request('blockchain.scripthash.listunspent', [scripthash]);
+    blockchainScripthash_getHistory(scripthash){
+        return this.request('blockchain.scripthash.get_history', [scripthash])
     }
-    blockchainScripthash_getHistory(scripthash) {
-        return this.request('blockchain.scripthash.get_history', [scripthash]);
+    blockchainScripthash_getMempool(scripthash){
+        return this.request('blockchain.scripthash.get_mempool', [scripthash])
+    }
+    blockchainScripthash_getProof(scripthash){
+        return this.request('blockchain.scripthash.get_proof', [scripthash])
+    }
+    blockchainScripthash_listunspent(scripthash){
+        return this.request('blockchain.scripthash.listunspent', [scripthash])
     }
     blockchainBlock_getHeader(height){
         return this.request('blockchain.block.get_header', [height])

--- a/lib/electrum_client.js
+++ b/lib/electrum_client.js
@@ -40,6 +40,9 @@ class ElectrumClient extends Client{
     blockchainAddress_listunspent(address){
         return this.request('blockchain.address.listunspent', [address])
     }
+    blockchainAddress_subscribe(address){
+        return this.request('blockchain.address.subscribe', [address])
+    }
     blockchainScripthash_getBalance(scripthash){
         return this.request('blockchain.scripthash.get_balance', [scripthash])
     }
@@ -49,11 +52,11 @@ class ElectrumClient extends Client{
     blockchainScripthash_getMempool(scripthash){
         return this.request('blockchain.scripthash.get_mempool', [scripthash])
     }
-    blockchainScripthash_getProof(scripthash){
-        return this.request('blockchain.scripthash.get_proof', [scripthash])
-    }
     blockchainScripthash_listunspent(scripthash){
         return this.request('blockchain.scripthash.listunspent', [scripthash])
+    }
+    blockchainScripthash_subscribe(scripthash){
+        return this.request('blockchain.scripthash.subscribe', [scripthash])
     }
     blockchainBlock_getHeader(height){
         return this.request('blockchain.block.get_header', [height])

--- a/lib/electrum_client.js
+++ b/lib/electrum_client.js
@@ -80,7 +80,7 @@ class ElectrumClient extends Client{
         return this.request('blockchain.transaction.broadcast', [rawtx])
     }
     blockchainTransaction_get(tx_hash, height){
-        return this.request('blockchain.transaction.get', [tx_hash, height])
+        return this.request('blockchain.transaction.get', [tx_hash])
     }
     blockchainTransaction_getMerkle(tx_hash, height){
         return this.request('blockchain.transaction.get_merkle', [tx_hash, height])

--- a/lib/electrum_client.js
+++ b/lib/electrum_client.js
@@ -40,6 +40,15 @@ class ElectrumClient extends Client{
     blockchainAddress_listunspent(address){
         return this.request('blockchain.address.listunspent', [address])
     }
+    blockchainScripthash_getBalance(scripthash) {
+        return this.request('blockchain.scripthash.get_balance', [scripthash]);
+    }
+    blockchainScripthash_listunspent(scripthash) {
+        return this.request('blockchain.scripthash.listunspent', [scripthash]);
+    }
+    blockchainScripthash_getHistory(scripthash) {
+        return this.request('blockchain.scripthash.get_history', [scripthash]);
+    }
     blockchainBlock_getHeader(height){
         return this.request('blockchain.block.get_header', [height])
     }


### PR DESCRIPTION
The stratum protocol [version 1.1](https://github.com/kyuupichan/electrumx/blob/master/docs/PROTOCOL.rst#version-11) adds support for queries by "scripthash" (`sha256(scriptPubKey)`). This adds support for new address formats, such as bech32 and CashAddr.

I added explicit support for these methods.