### PR TITLE
Fail gracefully if `tls` not found

### DIFF
--- a/lib/init_socket.js
+++ b/lib/init_socket.js
@@ -1,5 +1,4 @@
 'use strict'
-const tls = require('tls');
 const net = require('net');
 
 const TIMEOUT = 10000
@@ -10,6 +9,11 @@ const getSocket = (protocol, options) => {
         return new net.Socket();
     case 'tls':
     case 'ssl':
+        try {
+            const tls = require('tls');
+        } catch (e) {
+            throw new Error('tls package could not be loaded');
+        }
         return new tls.TLSSocket(options);
     }
     throw new Error('unknown protocol')


### PR DESCRIPTION
In some runtimes such as React Native, there is no `tls` module. While it can be shimmed in, this has not been done to date.

This module currently crashes if `tls` cannot be found, even if you are trying to create a plain `tcp` connection. 

This pull request moves the `require('tls')` call into the `tcp/ssl` branch of the case statement, making it only require TLS when TLS is actually being used.